### PR TITLE
Fix typo in extension key name

### DIFF
--- a/assets/javascripts/flowbite-plugin.js
+++ b/assets/javascripts/flowbite-plugin.js
@@ -2,4 +2,4 @@ import flowbiteContent from "../builds/flowbite.turbo" with { type: "text" }
 import flowbiteDatepicker from "../builds/flowbite-datepicker" with { type: "text" }
 
 export const plugin = require("flowbite/plugin");
-export const interactiveContent = { raw: `${flowbiteContent} ${flowbiteDatepicker}`, extenstion: "js" }
+export const interactiveContent = { raw: `${flowbiteContent} ${flowbiteDatepicker}`, extension: "js" }


### PR DESCRIPTION
Tailwind v3 uses the "extension" key for raw contents.

https://v3.tailwindcss.com/docs/content-configuration#configuring-raw-content

Anyway.. Tailwind v4 does no longer support raw content
https://github.com/tailwindlabs/tailwindcss/blob/v4.0.9/packages/tailwindcss/src/compat/apply-compat-hooks.ts#L359